### PR TITLE
Use `_strdup` instead of `strdup` on Windows

### DIFF
--- a/lmdb-simple/lmdb-simple.cabal
+++ b/lmdb-simple/lmdb-simple.cabal
@@ -73,6 +73,7 @@ test-suite hspec
   main-is:             hspec.hs
   other-modules:       Database.LMDB.SimpleSpec
                        Database.LMDB.Simple.DBRefSpec
+                       T1Spec
                        Harness
   build-depends:       base
                      , hspec

--- a/lmdb-simple/test/T1Spec.hs
+++ b/lmdb-simple/test/T1Spec.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE TemplateHaskell #-}
+-- | A regression test for https://github.com/GaloisInc/lmdb/issues/1. All of
+-- the interesting action happens in the Template Haskell splice that is run at
+-- compile time, which is the simplest way to test the behavior of GHC's runtime
+-- linker.
+module T1Spec (main, spec) where
+
+import Control.Exception (assert)
+import Database.LMDB.Simple (Limits(..), defaultLimits)
+import Test.Hspec (Spec, hspec)
+
+main :: IO ()
+main = hspec spec
+
+spec :: Spec
+spec = return ()
+
+$(assert (maxDatabases defaultLimits == 0) (return []))

--- a/lmdb/cbits/mdb.c
+++ b/lmdb/cbits/mdb.c
@@ -318,6 +318,8 @@ typedef HANDLE mdb_mutex_t, mdb_mutexref_t;
 #define GET_PAGESIZE(x) {SYSTEM_INFO si; GetSystemInfo(&si); (x) = si.dwPageSize;}
 #define	close(fd)	(CloseHandle(fd) ? 0 : -1)
 #define	munmap(ptr,len)	UnmapViewOfFile(ptr)
+// Work around https://gitlab.haskell.org/ghc/ghc/-/issues/22694
+#define strdup _strdup
 #ifdef PROCESS_QUERY_LIMITED_INFORMATION
 #define MDB_PROCESS_QUERY_LIMITED_INFORMATION PROCESS_QUERY_LIMITED_INFORMATION
 #else

--- a/lmdb/lmdb.cabal
+++ b/lmdb/lmdb.cabal
@@ -68,5 +68,17 @@ Library
     install-includes: lmdb.h midl.h
     c-sources: cbits/mdb.c cbits/midl.c
 
+  -- GHC 9.4.5, 9.6.1, and 9.6.2 on Windows do not link against mingwex, but
+  -- lmdb implicitly depends on this library due to its use of _GNU_SOURCE,
+  -- which implies mingwex on Windows. To avoid linker errors in the absence of
+  -- a mingwex dependency (see https://gitlab.haskell.org/ghc/ghc/-/issues/23533
+  -- for an example of this), we depend on mingwex explicitly here.
+  --
+  -- Other versions of GHC on Windows already depend on mingwex, so we guard
+  -- this behind appropriate conditionals.
+  if os(windows)
+    if (impl(ghc >= 9.4.5) && !impl(ghc >= 9.4.6)) || (impl(ghc >= 9.6.1) && !impl(ghc >= 9.6.3))
+      extra-libraries: mingwex
+
   ghc-options: -Wall
 


### PR DESCRIPTION
This works around https://gitlab.haskell.org/ghc/ghc/-/issues/22694 and fixes https://github.com/GaloisInc/lmdb/issues/1.